### PR TITLE
Updated to include description in jira query, modify Drop Down information

### DIFF
--- a/jiraExtension/popup.html
+++ b/jiraExtension/popup.html
@@ -60,7 +60,7 @@
                 <!-- <p><label for="comment">Comment</label><br /> -->
                 <textarea id="comment" name="comment" rows="10" placeholder="Add your comment here..." draggable="true" spellcheck="true"/></textarea>    
                 <div id="save">
-                    <input id="runButton" type="submit" value=" Run "/>
+                    <input id="runButton" type="submit" value=" Comment "/>
                     <span id="status-display"></span>
                 </div>
 <!--                 <div id="nav">

--- a/jiraExtension/popup.js
+++ b/jiraExtension/popup.js
@@ -101,7 +101,8 @@ function retrieveUsersJiras() {
             "fields": [
                 "summary",
                 "status",
-                "assignee"
+                "assignee",
+                "description"
             ]
         }
     );
@@ -120,15 +121,19 @@ function retrieveUsersJiras() {
         var jirasAssignedToUser = [];
 
         for (var i = data.issues.length - 1; i >= 0; i--) {
-            jirasAssignedToUser.push(data.issues[i].key);
+            jirasAssignedToUser.push(data.issues[i]);
         };
 
         var select = document.getElementById("jiraDropDown");
         for(var i = 0; i < jirasAssignedToUser.length; i++) {
             var jiraDropValue = jirasAssignedToUser[i];
-            var el = document.createElement("option");
-            el.textContent = jiraDropValue;
-            el.value = jiraDropValue;
+            var el            = document.createElement("option");
+            var summary       = jiraDropValue.fields.summary;
+
+            el.textContent = jiraDropValue.key + ': ' + summary.substring(0, 30);
+            el.title       = jiraDropValue.fields.description;
+            el.value       = jiraDropValue.key;
+
             select.appendChild(el);
         }
 


### PR DESCRIPTION
Updated drop down to include the jira key, colon, plus first 30
characters of summary to give more contxt

Update drop down so that each option includes a tooltip of the
description.  In some cases it blows out but its still context.  Depends
on how poorly the story was written
